### PR TITLE
add other packages metadata

### DIFF
--- a/tools/tools.json
+++ b/tools/tools.json
@@ -1182,6 +1182,550 @@
           "status": "recommended"
         }
       ]
+    },
+    {
+      "name": "tc-xt-esp32",
+      "description": "toolchain for esp32",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "a0eaa63f89688861d8389a6c65f04e13acf04e6713a43be9a5cddfd0489c272b",
+            "size": 460,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/toolchain-xtensa-esp32.zip"
+          },
+          "name": "toolchain-xtensa-esp32",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tc-xt-esp32s2",
+      "description": "toolchain for esp32-S2",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32s2"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "1bfa66746a563b06b3e62b51749afcc1e3db48bbae5e6685cd5ad990d8476580",
+            "size": 467,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/toolchain-xtensa-esp32s2.zip"
+          },
+          "name": "toolchain-xtensa-esp32s2",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tc-xt-esp32s3",
+      "description": "toolchain for esp32-S2",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32s3"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "31c5b935c74abb9c6556a7a7a4e3936ef3738031b9fc6639d6cc01497b475fe7",
+            "size": 467,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/toolchain-xtensa-esp32s3.zip"
+          },
+          "name": "toolchain-xtensa-esp32s3",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tc-rv32",
+      "description": "toolchain for rv32",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32c2", "esp32c3"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "b83a7e34b79a86ee9c90f710734b764ec509f8e12ee3810ca936f452d92671af",
+            "size": 484,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/toolchain-riscv32-esp.zip"
+          },
+          "name": "toolchain-xtensa-esp32rv32",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tc-ulp",
+      "description": "toolchain for esp32 ULP",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "f6ba698eb1b775e4864a30e6cf0a7289335091e712b2ee57e9b99ac26171450e",
+            "size": 467,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/toolchain-esp32ulp.zip"
+          },
+          "name": "toolchain-xtensa-esp32ulp",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-xt-gdb",
+      "description": "extensa debugger",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "0d8783c4015997481f4254592494afe112cc67e37441ec2d6a24edc2a52d4161",
+            "size": 419,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-gdb.zip"
+          },
+          "name": "xtensa-esp-elf-gdb",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-rv-gdb",
+      "description": "extensa debugger",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "esp32c2", "esp32c3"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "c7fa1e49f2ca077c765b4172ede08a4e16cfe1c9a9779260266e7a95a0a15829",
+            "size": 419,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-elf-gdb.zip"
+          },
+          "name": "xtensa-esp-rv-gdb",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-esptool",
+      "description": "esp tool uploader",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "e6b17461b55a352f40c3fc38f30ddc1c0fe9dc65e790bd0463b555ac2eee6758",
+            "size": 460758,
+            "url": "https://github.com/pioarduino/esptool/releases/download/v4.7.5/esptool.zip"
+          },
+          "name": "esptool",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-install",
+      "description": "esp installer",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "047ae47847edc572e154e9d91a0a1ce43a4bac752cb949b9c99414b39222f9d4",
+            "size": 50151,
+            "url": "https://github.com/pioarduino/esp_install/releases/download/v1.0.0/esp_install-v1.0.0.zip"
+          },
+          "name": "esptool",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-dfuutil",
+      "description": "esp dfuutil",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "c48c7f126860c47b2baf4040c1f5cf59e23fb3aa593e9e6fb48d97253b183f0a",
+            "size": 746,
+            "url": "https://github.com/pioarduino/esp_install/releases/download/v1.0.0/tool-dfuutil-arduino.zip"
+          },
+          "name": "esptool",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-openocd",
+      "description": "esp openocd",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "3e35efc8d83f0a1da6c7d10974afd8fea788e209995b2e4596fafca067127c35",
+            "size": 448,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-openocd-esp32.zip"
+          },
+          "name": "esptool",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-littlefs320",
+      "description": "esp littlefs320",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "on_request",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "152161c0f4de09a618890993157c416aecd3e956ad8aece4faaac15e064e543a",
+            "size": 421,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-mklittlefs_320.zip"
+          },
+          "name": "tool-mklittlefs",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-littlefs400",
+      "description": "esp littlefs400",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "804a452d1927611c38f1990eb30404c295455eebf2cd8594111be044c8df3b6a",
+            "size": 421,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-mklittlefs_400.zip"
+          },
+          "name": "tool-mklittlefs",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-fatfs",
+      "description": "esp fatfs generator",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "on_request",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "ff3c31a6cff34fca99b54ae40d6e29e1c429219c49c339e428c4aee36ec5a289",
+            "size": 711,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-mkfatfs.zip"
+          },
+          "name": "tool-mkfatfs",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-spiffs",
+      "description": "esp spiffs generator",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "on_request",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "50a4fe44a01dd8589b3708d5252900f001aa6786af6d6dd0cd6be3d889cb7bbe",
+            "size": 714,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-mkspiffs.zip"
+          },
+          "name": "tool-mkspiffs",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-cmake",
+      "description": "cmake tool",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "2f6737ded4af6af15874bd4880b78f5752aee123b7564c7315224d8ff7b18609",
+            "size": 374,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-cmake.zip"
+          },
+          "name": "tool-cmake",
+          "status": "recommended"
+        }
+      ]
+    },
+    {
+      "name": "tl-ninja",
+      "description": "ninja tool",
+      "strip_container_dirs": 1,
+      "export_paths": [
+        [
+          ""
+        ]
+      ],
+      "info_url": "https://github.com/espressif/arduino-esp32",
+      "install": "always",
+      "license": "LGPL-2.1",
+      "is_executable": false,
+      "supported_targets": [
+        "all"
+      ],
+      "version_cmd": [
+        ""
+      ],
+      "version_regex": "",
+      "versions": [
+        {
+          "any": {
+            "sha256": "78a271693843d994b80f81105a4890e5a2bf88e85c8fb109a816e324041ceda7",
+            "size": 415,
+            "url": "https://github.com/pioarduino/registry/releases/download/0.0.1/tool-ninja.zip"
+          },
+          "name": "tool-ninja",
+          "status": "recommended"
+        }
+      ]
     }
   ],
   "version": 1


### PR DESCRIPTION
added other pkg data,

my concern is that most tools are just zips with only one manifest file, is that ok?

```
419  riscv32-esp-elf-gdb.zip
467  toolchain-esp32ulp.zip
484  toolchain-riscv32-esp.zip
467  toolchain-xtensa-esp32s2.zip
467  toolchain-xtensa-esp32s3.zip
460  toolchain-xtensa-esp32.zip
374  tool-cmake.zip
746  tool-dfuutil-arduino.zip
711  tool-mkfatfs.zip
421  tool-mklittlefs_320.zip
421  tool-mklittlefs_400.zip
714  tool-mkspiffs.zip
415  tool-ninja.zip
448  tool-openocd-esp32.zip
419  xtensa-esp-elf-gdb.zip
```