### PR TITLE
Improve resume support 

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -923,13 +923,6 @@ def download(url: str, destination: str, is_retry: bool = False) -> Union[None, 
     """
     info(f'Downloading {url}')
     info(f'Destination: {destination}')
-    
-    # Check for existing partial download to resume (skip on retry to start fresh)
-    resume_from = 0
-    if not is_retry and os.path.isfile(destination):
-        resume_from = os.path.getsize(destination)
-        if resume_from > 0:
-            info(f'Found partial download ({resume_from} bytes), will attempt to resume')
 
     # Get SSL fallback contexts for robust SSL handling
     ssl_contexts = get_ssl_fallback_contexts(url)
@@ -939,6 +932,13 @@ def download(url: str, destination: str, is_retry: bool = False) -> Union[None, 
         try:
             info(f'Trying SSL configuration: {config_name}')
             
+            # Check for existing partial download to resume (skip on retry to start fresh)
+            resume_from = 0
+            if not is_retry and os.path.isfile(destination):
+                resume_from = os.path.getsize(destination)
+                if resume_from > 0:
+                    info(f'Found partial download ({resume_from} bytes), will attempt to resume')
+
             if url.startswith('https'):
                 # HTTPS with specific SSL context
                 headers = {'User-Agent': 'pioarduino'}


### PR DESCRIPTION
The resume check should be moved down into the `for config_name, ctx in ssl_contexts:` loop:
- Right now it resumes when idf_tools.py is called a second time so it works
- However if this is inside the loop it can resume immediately and greatly reduce download times for those with unstable internet

Don't need a new release as the current version works but if you wanted to that would ok as this is an big improvement for some people. Could update 55.03.31-2.

Thanks and sorry I didn't catch this earlier I did some testing today simulating an unstable connection. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of partial downloads during SSL-based retry attempts to enhance reliability when connectivity issues occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->